### PR TITLE
add script to fix ios imports

### DIFF
--- a/sdk/fix_ios_imports.sh
+++ b/sdk/fix_ios_imports.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+find Ssi.xcframework -name '*.h' | xargs sed -i '' -e 's~@import Foundation;~#import <Foundation/Foundation.h>~g';

--- a/sdk/magefile.go
+++ b/sdk/magefile.go
@@ -233,7 +233,10 @@ func IOS() error {
 
 	fmt.Println("Building iOS...")
 	bindIOS := sh.RunCmd(gomobile, "bind", "-target", "ios", "-tags", "jwx_es256k")
-	return bindIOS("./src/ssi")
+	error := bindIOS("./src/ssi")
+	sh.Run("./fix_ios_imports.sh")
+
+	return error
 }
 
 // Android Generates the Android packages


### PR DESCRIPTION
migrates module import of foundation to header import in order to maintain compat with CPP