### PR TITLE
Provide publicJwk in generateDIDKeyResult

### DIFF
--- a/react-native-ssi/example/src/App.tsx
+++ b/react-native-ssi/example/src/App.tsx
@@ -12,8 +12,7 @@ import { generateDidKey, expandDidKey } from 'react-native-ssi';
 
 export function App() {
   const [logDisplay, setLogDisplay] = React.useState('App Initialized. \n\n');
-  const [didKey, setDidKey] = React.useState<string>('');
-  // const [privateJwk, setPrivateJwk] = React.useState<Record<string, unknown>>();
+  const [did, setDid] = React.useState<string>('');
 
   const addLogLine = (text: unknown) => {
     setLogDisplay(
@@ -30,22 +29,18 @@ export function App() {
               style={styles.button}
               onPress={() => {
                 generateDidKey('RSA').then((result) => {
-                  setDidKey(result.didKey);
-                  addLogLine(didKey);
-
-                  // currently unused
-                  // setPrivateJwk(result.privateJwk);
-                  // addLogLine(privateJwk);
+                  setDid(result.did);
+                  addLogLine(did);
                 });
               }}
             >
               <Text style={styles.buttonText}>Generate DID</Text>
             </TouchableOpacity>
             <TouchableOpacity
-              disabled={!didKey}
+              disabled={!did}
               style={styles.button}
               onPress={() => {
-                expandDidKey(didKey).then((result) => {
+                expandDidKey(did).then((result) => {
                   addLogLine(result);
                 });
               }}

--- a/react-native-ssi/src/types.ts
+++ b/react-native-ssi/src/types.ts
@@ -1,5 +1,6 @@
 export type GenerateDidKeyResult = {
-  didKey: string;
+  did: string;
+  publicJwk: Record<string, unknown>;
   privateJwk: Record<string, unknown>;
 };
 

--- a/sdk/src/ssi/did.go
+++ b/sdk/src/ssi/did.go
@@ -26,10 +26,12 @@ func GenerateDIDKey(kt string) ([]byte, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "creating private jwk")
 	}
+
 	publicJwk, err := privateJwk.PublicKey()
 	if err != nil {
 		return nil, errors.Wrap(err, "creating public jwk")
 	}
+
 	resultBytes, err := json.Marshal(generateDIDKeyResult{
 		DID:               string(*didKey),
 		PublicJSONWebKey:  publicJwk,

--- a/sdk/src/ssi/did.go
+++ b/sdk/src/ssi/did.go
@@ -9,7 +9,8 @@ import (
 )
 
 type generateDIDKeyResult struct {
-	DIDKey            string  `json:"didKey"`
+	DID               string  `json:"did"`
+	PublicJSONWebKey  jwk.Key `json:"publicJwk"`
 	PrivateJSONWebKey jwk.Key `json:"privateJwk"`
 }
 
@@ -20,12 +21,18 @@ func GenerateDIDKey(kt string) ([]byte, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "generating did key")
 	}
+
 	privateJwk, err := crypto.PrivateKeyToJWK(privateKey)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating jwk")
+		return nil, errors.Wrap(err, "creating private jwk")
+	}
+	publicJwk, err := privateJwk.PublicKey()
+	if err != nil {
+		return nil, errors.Wrap(err, "creating public jwk")
 	}
 	resultBytes, err := json.Marshal(generateDIDKeyResult{
-		DIDKey:            string(*didKey),
+		DID:               string(*didKey),
+		PublicJSONWebKey:  publicJwk,
 		PrivateJSONWebKey: privateJwk,
 	})
 	if err != nil {

--- a/sdk/src/ssi/did_test.go
+++ b/sdk/src/ssi/did_test.go
@@ -15,6 +15,7 @@ func TestGenerateDIDKey(t *testing.T) {
 
 	var result map[string]any
 	assert.NoError(t, json.Unmarshal(resultBytes, &result))
-	assert.True(t, strings.HasPrefix(result["didKey"].(string), "did:key:"))
+	assert.True(t, strings.HasPrefix(result["did"].(string), "did:key:"))
+	assert.NotEmpty(t, result["publicJwk"])
 	assert.NotEmpty(t, result["privateJwk"])
 }


### PR DESCRIPTION
Provides the `publicJwk` to caller in addition to the DID and privateJwk. 

This `publicJwk` will be used to verify a verifiable credential JWT in a future PR.