### PR TITLE
Accept JWKs in for credential sign/verify functions

### DIFF
--- a/sdk/src/ssi/credential_test.go
+++ b/sdk/src/ssi/credential_test.go
@@ -4,30 +4,48 @@ import (
 	"testing"
 
 	"github.com/TBD54566975/ssi-sdk/credential"
+	"github.com/TBD54566975/ssi-sdk/crypto"
+	ssi "github.com/TBD54566975/ssi-sdk/crypto"
 	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSignAndVerifyVCJWT(t *testing.T) {
-	keyPair, err := GenerateEd25519Key()
+	// Create a new public & private JWK
+	_, privKey, err := ssi.GenerateEd25519Key()
 	assert.NoError(t, err)
-	assert.NotEmpty(t, keyPair)
+	assert.NotEmpty(t, privKey)
+
+	privateJwk, err := crypto.PrivateKeyToJWK(privKey)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, privateJwk)
+
+	publicJwk, err := privateJwk.PublicKey()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, publicJwk)
+
+	privateJwkBytes, err := json.Marshal(privateJwk)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, privateJwkBytes)
+
+	publicJwkBytes, err := json.Marshal(publicJwk)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, publicJwkBytes)
 
 	// Create a new Verifiable Credential
-	vc := getSampleCredential()
-	assert.NotEmpty(t, vc)
-
-	vcBytes, err := json.Marshal(vc)
+	vcBytes, err := json.Marshal(getSampleCredential())
 	assert.NoError(t, err)
 	assert.NotEmpty(t, vcBytes)
 
 	// sign it
-	vcJWT := SignVerifiableCredentialJWT("test-key-id", keyPair.KeyType, keyPair.PrivKey, vcBytes)
-	assert.NotEmpty(t, vcJWT)
+	jwt, err := SignVerifiableCredentialJWT("test-key-id", privateJwkBytes, vcBytes)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, jwt)
 
 	// verify it
-	valid := VerifyVerifiableCredentialJWT("test-key-id", keyPair.KeyType, keyPair.PubKey, vcJWT)
-	assert.True(t, valid)
+	vc, err := VerifyVerifiableCredentialJWT("test-key-id", publicJwkBytes, jwt)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, vc)
 }
 
 func getSampleCredential() credential.VerifiableCredential {


### PR DESCRIPTION
Modifies the two credential functions:
* Accept the privateJWK in the `SignVerifiableCredentialJWT` function in lieu of `keyType` and `privateKey`
* Accept the publicJWK in the `VerifyVerifiableCredentialJWT` function in lieu of `keyType` and `publicKey`
