### PR TITLE
Expose BuildPresentationSubmission to mobile clients

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.1
+          go-version: 1.20.2
 
       - name: Install Mage
         run: go install github.com/magefile/mage
@@ -40,8 +40,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20.1
-
+          go-version: 1.20.2
+          
       - name: Install Mage
         run: go install github.com/magefile/mage
 

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -35,9 +35,11 @@ require (
 	github.com/multiformats/go-multibase v0.2.0 // indirect
 	github.com/multiformats/go-multicodec v0.8.1 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
+	github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852 // indirect
 	github.com/piprate/json-gold v0.5.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pquerna/cachecontrol v0.1.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v5 v5.2.0 // indirect
 	golang.org/x/crypto v0.7.0 // indirect
 	golang.org/x/mobile v0.0.0-20230301163155-e0f57694e12c // indirect
 	golang.org/x/sys v0.6.0 // indirect

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -56,6 +56,8 @@ github.com/multiformats/go-multicodec v0.8.1 h1:ycepHwavHafh3grIbR1jIXnKCsFm0fqs
 github.com/multiformats/go-multicodec v0.8.1/go.mod h1:L3QTQvMIaVBkXOXXtVmYE+LI16i14xuaojr/H7Ai54k=
 github.com/multiformats/go-varint v0.0.7 h1:sWSGR+f/eu5ABZA2ZpYKBILXTTs9JWpdEM/nEGOHFS8=
 github.com/multiformats/go-varint v0.0.7/go.mod h1:r8PUYw/fD/SjBCiKOoDlGF6QawOELpZAu9eioSos/OU=
+github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852 h1:Yl0tPBa8QPjGmesFh1D0rDy+q1Twx6FyU7VWHi8wZbI=
+github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852/go.mod h1:eqOVx5Vwu4gd2mmMZvVZsgIqNSaW3xxRThUJ0k/TPk4=
 github.com/piprate/json-gold v0.5.0 h1:RmGh1PYboCFcchVFuh2pbSWAZy4XJaqTMU4KQYsApbM=
 github.com/piprate/json-gold v0.5.0/go.mod h1:WZ501QQMbZZ+3pXFPhQKzNwS1+jls0oqov3uQ2WasLs=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -65,6 +67,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/pquerna/cachecontrol v0.1.0 h1:yJMy84ti9h/+OEWa752kBTKv4XC30OtVVHYv/8cTqKc=
 github.com/pquerna/cachecontrol v0.1.0/go.mod h1:NrUG3Z7Rdu85UNR3vm7SOsl1nFIeSiQnrHV5K9mBcUI=
 github.com/rwtodd/Go.Sed v0.0.0-20210816025313-55464686f9ef/go.mod h1:8AEUvGVi2uQ5b24BIhcr0GCcpd/RNAFWaN2CJFrWIIQ=
+github.com/santhosh-tekuri/jsonschema/v5 v5.2.0 h1:WCcC4vZDS1tYNxjWlwRJZQy28r8CMoggKnxNzxsVDMQ=
+github.com/santhosh-tekuri/jsonschema/v5 v5.2.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/sdk/src/ssi/exchange.go
+++ b/sdk/src/ssi/exchange.go
@@ -1,0 +1,51 @@
+package ssi
+
+import (
+	"encoding/json"
+
+	"github.com/TBD54566975/ssi-sdk/credential/exchange"
+	"github.com/TBD54566975/ssi-sdk/crypto"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/pkg/errors"
+)
+
+/*
+Parameters:
+
+	keyID: id of key to sign resulting PresentationSubmission with
+	privateJWKBytes: bytes of privateJWK to sign resulting PresentationSubmission with
+	pdBytes: bytes of PresentationDefinition to build the PresentationSubmission for
+	claimsBytes: bytes of an array of PresentationClaim bytes that are evaluated to potentially fulfill PresentationDefinition with
+	embedTarget: target format to embed the resulting PresentationSubmission within
+
+Returns:
+
+	bytes of VerifiablePresentation, which embeds a PresentationSubmission within the provided embedTarget
+*/
+func BuildPresentationSubmission(keyID string, privateJWKBytes []byte, pdBytes []byte, claimsBytes []byte, embedTarget string) ([]byte, error) {
+	key, err := jwk.ParseKey(privateJWKBytes)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing key")
+	}
+
+	signer, err := crypto.NewJWTSignerFromKey(keyID, key)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating signer")
+	}
+
+	var pd exchange.PresentationDefinition
+	if err := json.Unmarshal(pdBytes, &pd); err != nil {
+		return nil, errors.Wrap(err, "unmarshalling PresentationDefinition")
+	}
+
+	if err := pd.IsValid(); err != nil {
+		return nil, errors.Wrap(err, "invalid PresentationDefinition")
+	}
+
+	var claims []exchange.PresentationClaim
+	if err := json.Unmarshal(claimsBytes, &claims); err != nil {
+		return nil, errors.Wrap(err, "unmarshalling claims array")
+	}
+
+	return exchange.BuildPresentationSubmission(*signer, pd, claims, exchange.EmbedTarget(embedTarget))
+}

--- a/sdk/src/ssi/exchange_test.go
+++ b/sdk/src/ssi/exchange_test.go
@@ -1,0 +1,84 @@
+package ssi
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/TBD54566975/ssi-sdk/credential"
+	"github.com/TBD54566975/ssi-sdk/credential/exchange"
+	"github.com/TBD54566975/ssi-sdk/crypto"
+	"github.com/TBD54566975/ssi-sdk/cryptosuite"
+	"github.com/TBD54566975/ssi-sdk/did"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildPresentationSubmission(t *testing.T) {
+	privateKey, _, _ := did.GenerateDIDKey("RSA")
+	privateJWK, _ := crypto.PrivateKeyToJWK(privateKey)
+	kid := "test-key"
+
+	privateJWKBytes, err := json.Marshal(privateJWK)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, privateJWKBytes)
+
+	pd := getTestPresentationDefinition()
+	claim := getTestPresentationClaim()
+
+	pdBytes, err := json.Marshal(&pd)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, pdBytes)
+
+	claimsBytes, err := json.Marshal([]exchange.PresentationClaim{claim})
+	assert.NoError(t, err)
+	assert.NotEmpty(t, claimsBytes)
+
+	bytes, err := BuildPresentationSubmission(kid, privateJWKBytes, pdBytes, claimsBytes, string(exchange.JWTVPTarget))
+	assert.NoError(t, err)
+	assert.NotEmpty(t, bytes)
+}
+
+func getTestPresentationDefinition() exchange.PresentationDefinition {
+	return exchange.PresentationDefinition{
+		ID: "test-id",
+		InputDescriptors: []exchange.InputDescriptor{
+			{
+				ID: "id-1",
+				Constraints: &exchange.Constraints{
+					Fields: []exchange.Field{
+						{
+							Path:    []string{"$.vc.issuer", "$.issuer"},
+							ID:      "issuer-input-descriptor",
+							Purpose: "need to check the issuer",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func getTestPresentationClaim() exchange.PresentationClaim {
+	testVC := getTestVerifiableCredential()
+
+	return exchange.PresentationClaim{
+		Credential:                    &testVC,
+		LDPFormat:                     exchange.LDPVC.Ptr(),
+		SignatureAlgorithmOrProofType: string(cryptosuite.JSONWebSignature2020),
+	}
+}
+
+func getTestVerifiableCredential() credential.VerifiableCredential {
+	return credential.VerifiableCredential{
+		Context: []any{"https://www.w3.org/2018/credentials/v1",
+			"https://w3id.org/security/suites/jws-2020/v1"},
+		ID:           "test-verifiable-credential",
+		Type:         []string{"VerifiableCredential"},
+		Issuer:       "test-issuer",
+		IssuanceDate: "2021-01-01T19:23:24Z",
+		CredentialSubject: map[string]any{
+			"id":      "test-vc-id",
+			"company": "Block",
+			"website": "https://block.xyz",
+		},
+	}
+}

--- a/sdk/src/ssi/exchange_test.go
+++ b/sdk/src/ssi/exchange_test.go
@@ -2,6 +2,7 @@ package ssi
 
 import (
 	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/TBD54566975/ssi-sdk/credential"
@@ -9,8 +10,23 @@ import (
 	"github.com/TBD54566975/ssi-sdk/crypto"
 	"github.com/TBD54566975/ssi-sdk/cryptosuite"
 	"github.com/TBD54566975/ssi-sdk/did"
+	"github.com/TBD54566975/ssi-sdk/schema"
 	"github.com/stretchr/testify/assert"
 )
+
+// TestMain is used to set up schema caching in order to load all schemas locally
+func TestMain(m *testing.M) {
+	localSchemas, err := schema.GetAllLocalSchemas()
+	if err != nil {
+		os.Exit(1)
+	}
+	loader, err := schema.NewCachingLoader(localSchemas)
+	if err != nil {
+		os.Exit(1)
+	}
+	loader.EnableHTTPCache()
+	os.Exit(m.Run())
+}
 
 func TestBuildPresentationSubmission(t *testing.T) {
 	privateKey, _, _ := did.GenerateDIDKey("RSA")


### PR DESCRIPTION
Converts `ssi-sdk`'s `exchange.BuildPresentationSubmission` function parameters into primitive data types that gomobile can work with. This function can then be called on mobile using marshalled JSON objects representing the required parameters.

Because this function has many parameters in very primitive forms, I documented each of them as well as the return type, in the comments.