### PR TITLE
Bump ssi-sdk and update to support all breaking changes

### DIFF
--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -3,7 +3,7 @@ module github.com/TBD54566975/ssi-sdk-mobile
 go 1.20
 
 require (
-	github.com/TBD54566975/ssi-sdk v0.0.3-alpha.0.20230410220001-cbd9818e8367
+	github.com/TBD54566975/ssi-sdk v0.0.3-alpha.0.20230412184407-ba89e4893e6a
 	github.com/goccy/go-json v0.10.2
 	github.com/lestrrat-go/jwx/v2 v2.0.9
 	github.com/magefile/mage v1.14.0

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -3,7 +3,7 @@ module github.com/TBD54566975/ssi-sdk-mobile
 go 1.20
 
 require (
-	github.com/TBD54566975/ssi-sdk v0.0.3-alpha.0.20230328175208-0ce55b2b0262
+	github.com/TBD54566975/ssi-sdk v0.0.3-alpha.0.20230410220001-cbd9818e8367
 	github.com/goccy/go-json v0.10.2
 	github.com/lestrrat-go/jwx/v2 v2.0.9
 	github.com/magefile/mage v1.14.0
@@ -14,6 +14,7 @@ require (
 )
 
 require (
+	github.com/btcsuite/btcd/btcec/v2 v2.3.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -1,5 +1,7 @@
-github.com/TBD54566975/ssi-sdk v0.0.3-alpha.0.20230328175208-0ce55b2b0262 h1:mMd9kTYtqEHAbiYwtnH94qyY4Meanp0mWkOktrZyVv4=
-github.com/TBD54566975/ssi-sdk v0.0.3-alpha.0.20230328175208-0ce55b2b0262/go.mod h1:Ro9+HDADuYcLnCYKIL8pu92XWITKetTPOqfwLThplO0=
+github.com/TBD54566975/ssi-sdk v0.0.3-alpha.0.20230410220001-cbd9818e8367 h1:dYkvkaLS7fLBPy06PDal2DZBHYiD79Z//1sOjaojR1U=
+github.com/TBD54566975/ssi-sdk v0.0.3-alpha.0.20230410220001-cbd9818e8367/go.mod h1:Ro9+HDADuYcLnCYKIL8pu92XWITKetTPOqfwLThplO0=
+github.com/btcsuite/btcd/btcec/v2 v2.3.2 h1:5n0X6hX0Zk+6omWcihdYvdAlGf2DfasC0GMf7DClJ3U=
+github.com/btcsuite/btcd/btcec/v2 v2.3.2/go.mod h1:zYzJ8etWJQIv1Ogk7OzpWjowwOdXY1W/17j2MW85J04=
 github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce h1:YtWJF7RHm2pYCvA5t0RPmAaLUhREsKuKd+SLhxFbFeQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -23,6 +25,7 @@ github.com/hyperledger/aries-framework-go v0.1.9 h1:qwfjV/zGaH745AMyQwpL3296uRCb
 github.com/hyperledger/aries-framework-go v0.1.9/go.mod h1:qrOxEGVsu8M2RahaJgM8nz9AcAHjR/dKd1JIJ3ieJhY=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20221025204933-b807371b6f1e h1:SxbXlF39661T9w/L9PhVdtbJfJ51Pm4JYEEW6XfZHEQ=
 github.com/hyperledger/aries-framework-go/spi v0.0.0-20221025204933-b807371b6f1e/go.mod h1:oryUyWb23l/a3tAP9KW+GBbfcfqp9tZD4y5hSkFrkqI=
+github.com/jarcoal/httpmock v1.3.0 h1:2RJ8GP0IIaWwcC9Fp2BmVi8Kog3v2Hn7VXM3fTd+nuc=
 github.com/kilic/bls12-381 v0.1.1-0.20210503002446-7b7597926c69 h1:kMJlf8z8wUcpyI+FQJIdGjAhfTww1y0AbQEv86bpVQI=
 github.com/kilic/bls12-381 v0.1.1-0.20210503002446-7b7597926c69/go.mod h1:tlkavyke+Ac7h8R3gZIjI5LKBcvMlSWnXNMgT3vZXo8=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -1,5 +1,7 @@
 github.com/TBD54566975/ssi-sdk v0.0.3-alpha.0.20230410220001-cbd9818e8367 h1:dYkvkaLS7fLBPy06PDal2DZBHYiD79Z//1sOjaojR1U=
 github.com/TBD54566975/ssi-sdk v0.0.3-alpha.0.20230410220001-cbd9818e8367/go.mod h1:Ro9+HDADuYcLnCYKIL8pu92XWITKetTPOqfwLThplO0=
+github.com/TBD54566975/ssi-sdk v0.0.3-alpha.0.20230412184407-ba89e4893e6a h1:HLvYZYBdVSTCMRpOfrQtNodl/LujrzoeFrgv82xkhBk=
+github.com/TBD54566975/ssi-sdk v0.0.3-alpha.0.20230412184407-ba89e4893e6a/go.mod h1:Ro9+HDADuYcLnCYKIL8pu92XWITKetTPOqfwLThplO0=
 github.com/btcsuite/btcd/btcec/v2 v2.3.2 h1:5n0X6hX0Zk+6omWcihdYvdAlGf2DfasC0GMf7DClJ3U=
 github.com/btcsuite/btcd/btcec/v2 v2.3.2/go.mod h1:zYzJ8etWJQIv1Ogk7OzpWjowwOdXY1W/17j2MW85J04=
 github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce h1:YtWJF7RHm2pYCvA5t0RPmAaLUhREsKuKd+SLhxFbFeQ=

--- a/sdk/src/ssi/credential.go
+++ b/sdk/src/ssi/credential.go
@@ -10,7 +10,7 @@ import (
 )
 
 // SignVerifiableCredentialJWT takes in a did, key ID, private JWK, and a verifiable credential
-// The keyID and privateJWK are used for signing the credential, which will be packaged as
+// The did, keyID, and privateJWK are used for signing the credential, which will be packaged as
 // a JWT according to the VC-JWT 1.0 specification.
 // The function returns a string representation of a JWT.
 func SignVerifiableCredentialJWT(did string, keyID string, privateJSONWebKey []byte, vcJSONBytes []byte) (string, error) {
@@ -37,16 +37,16 @@ func SignVerifiableCredentialJWT(did string, keyID string, privateJSONWebKey []b
 	return string(signedCredential), nil
 }
 
-// VerifyVerifiableCredentialJWT takes in a did, key ID, public JWK, and a JWT string
-// The keyID and publicJWK are used for verifying the JWT.
+// VerifyVerifiableCredentialJWT takes in a did, public JWK, and a JWT string
+// The did and publicJWK are used for verifying the JWT.
 // The function returns the marshaled JSON representation of the verified Verifiable Credential.
-func VerifyVerifiableCredentialJWT(did string, keyID string, publicJSONWebKey []byte, jwt string) ([]byte, error) {
+func VerifyVerifiableCredentialJWT(did string, publicJSONWebKey []byte, jwt string) ([]byte, error) {
 	key, err := jwk.ParseKey(publicJSONWebKey)
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing key")
 	}
 
-	verifier, err := crypto.NewJWTVerifierFromKey(did, keyID, key)
+	verifier, err := crypto.NewJWTVerifierFromKey(did, key)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating verifier")
 	}

--- a/sdk/src/ssi/credential.go
+++ b/sdk/src/ssi/credential.go
@@ -9,17 +9,17 @@ import (
 	"github.com/pkg/errors"
 )
 
-// SignVerifiableCredentialJWT takes in a key ID, private JWK, and a verifiable credential
+// SignVerifiableCredentialJWT takes in a did, key ID, private JWK, and a verifiable credential
 // The keyID and privateJWK are used for signing the credential, which will be packaged as
 // a JWT according to the VC-JWT 1.0 specification.
 // The function returns a string representation of a JWT.
-func SignVerifiableCredentialJWT(keyID string, privateJSONWebKey []byte, vcJSONBytes []byte) (string, error) {
+func SignVerifiableCredentialJWT(did string, keyID string, privateJSONWebKey []byte, vcJSONBytes []byte) (string, error) {
 	key, err := jwk.ParseKey(privateJSONWebKey)
 	if err != nil {
 		return "", errors.Wrap(err, "parsing key")
 	}
 
-	signer, err := crypto.NewJWTSignerFromKey(keyID, key)
+	signer, err := crypto.NewJWTSignerFromKey(did, keyID, key)
 	if err != nil {
 		return "", errors.Wrap(err, "creating signer")
 	}
@@ -37,21 +37,21 @@ func SignVerifiableCredentialJWT(keyID string, privateJSONWebKey []byte, vcJSONB
 	return string(signedCredential), nil
 }
 
-// VerifyVerifiableCredentialJWT takes in a key ID, public JWK, and a JWT string
+// VerifyVerifiableCredentialJWT takes in a did, key ID, public JWK, and a JWT string
 // The keyID and publicJWK are used for verifying the JWT.
 // The function returns the marshaled JSON representation of the verified Verifiable Credential.
-func VerifyVerifiableCredentialJWT(keyID string, publicJSONWebKey []byte, jwt string) ([]byte, error) {
+func VerifyVerifiableCredentialJWT(did string, keyID string, publicJSONWebKey []byte, jwt string) ([]byte, error) {
 	key, err := jwk.ParseKey(publicJSONWebKey)
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing key")
 	}
 
-	verifier, err := crypto.NewJWTVerifierFromKey(keyID, key)
+	verifier, err := crypto.NewJWTVerifierFromKey(did, keyID, key)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating verifier")
 	}
 
-	vc, err := signing.VerifyVerifiableCredentialJWT(*verifier, jwt)
+	_, _, vc, err := signing.VerifyVerifiableCredentialJWT(*verifier, jwt)
 	if err != nil {
 		return nil, errors.Wrap(err, "verifying jwt")
 	}

--- a/sdk/src/ssi/credential_test.go
+++ b/sdk/src/ssi/credential_test.go
@@ -11,6 +11,9 @@ import (
 )
 
 func TestSignAndVerifyVCJWT(t *testing.T) {
+	did := "test-did"
+	kid := "test-key-id"
+
 	// Create a new public & private JWK
 	_, privKey, err := ssi.GenerateEd25519Key()
 	assert.NoError(t, err)
@@ -38,12 +41,12 @@ func TestSignAndVerifyVCJWT(t *testing.T) {
 	assert.NotEmpty(t, vcBytes)
 
 	// sign it
-	jwt, err := SignVerifiableCredentialJWT("test-key-id", privateJwkBytes, vcBytes)
+	jwt, err := SignVerifiableCredentialJWT(did, kid, privateJwkBytes, vcBytes)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, jwt)
 
 	// verify it
-	vc, err := VerifyVerifiableCredentialJWT("test-key-id", publicJwkBytes, jwt)
+	vc, err := VerifyVerifiableCredentialJWT(did, kid, publicJwkBytes, jwt)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, vc)
 }

--- a/sdk/src/ssi/credential_test.go
+++ b/sdk/src/ssi/credential_test.go
@@ -46,7 +46,7 @@ func TestSignAndVerifyVCJWT(t *testing.T) {
 	assert.NotEmpty(t, jwt)
 
 	// verify it
-	vc, err := VerifyVerifiableCredentialJWT(did, kid, publicJwkBytes, jwt)
+	vc, err := VerifyVerifiableCredentialJWT(did, publicJwkBytes, jwt)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, vc)
 }

--- a/sdk/src/ssi/exchange.go
+++ b/sdk/src/ssi/exchange.go
@@ -12,8 +12,10 @@ import (
 /*
 Parameters:
 
+	did: DID of the entity signing the resulting PresentationSubmission
 	keyID: id of key to sign resulting PresentationSubmission with
 	privateJWKBytes: bytes of privateJWK to sign resulting PresentationSubmission with
+	requester: DID of entity requesting the resulting PresentationSubmission
 	pdBytes: bytes of PresentationDefinition to build the PresentationSubmission for
 	claimsBytes: bytes of an array of PresentationClaim bytes that are evaluated to potentially fulfill PresentationDefinition with
 	embedTarget: target format to embed the resulting PresentationSubmission within
@@ -22,13 +24,13 @@ Returns:
 
 	bytes of VerifiablePresentation, which embeds a PresentationSubmission within the provided embedTarget
 */
-func BuildPresentationSubmission(keyID string, privateJWKBytes []byte, pdBytes []byte, claimsBytes []byte, embedTarget string) ([]byte, error) {
+func BuildPresentationSubmission(did string, keyID string, privateJWKBytes []byte, requester string, pdBytes []byte, claimsBytes []byte, embedTarget string) ([]byte, error) {
 	key, err := jwk.ParseKey(privateJWKBytes)
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing key")
 	}
 
-	signer, err := crypto.NewJWTSignerFromKey(keyID, key)
+	signer, err := crypto.NewJWTSignerFromKey(did, keyID, key)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating signer")
 	}
@@ -47,5 +49,5 @@ func BuildPresentationSubmission(keyID string, privateJWKBytes []byte, pdBytes [
 		return nil, errors.Wrap(err, "unmarshalling claims array")
 	}
 
-	return exchange.BuildPresentationSubmission(*signer, pd, claims, exchange.EmbedTarget(embedTarget))
+	return exchange.BuildPresentationSubmission(*signer, requester, pd, claims, exchange.EmbedTarget(embedTarget))
 }

--- a/sdk/src/ssi/exchange_test.go
+++ b/sdk/src/ssi/exchange_test.go
@@ -29,9 +29,10 @@ func TestMain(m *testing.M) {
 }
 
 func TestBuildPresentationSubmission(t *testing.T) {
-	privateKey, _, _ := did.GenerateDIDKey("RSA")
+	privateKey, did, _ := did.GenerateDIDKey("RSA")
 	privateJWK, _ := crypto.PrivateKeyToJWK(privateKey)
 	kid := "test-key"
+	requester := "requester"
 
 	privateJWKBytes, err := json.Marshal(privateJWK)
 	assert.NoError(t, err)
@@ -48,7 +49,7 @@ func TestBuildPresentationSubmission(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, claimsBytes)
 
-	bytes, err := BuildPresentationSubmission(kid, privateJWKBytes, pdBytes, claimsBytes, string(exchange.JWTVPTarget))
+	bytes, err := BuildPresentationSubmission(string(*did), kid, privateJWKBytes, requester, pdBytes, claimsBytes, string(exchange.JWTVPTarget))
 	assert.NoError(t, err)
 	assert.NotEmpty(t, bytes)
 }


### PR DESCRIPTION
Updates `ssi-sdk` to latest, and fixes the breaking changes that were introduced in https://github.com/TBD54566975/ssi-sdk/pull/341

Will create a follow-up PR to:
* `mage ios` & `mage android`
* update the example app to support these new breaking changes