### PR TITLE
Credential Application validation against a Credential Manifest

### DIFF
--- a/sdk/src/ssi/manifest_validation.go
+++ b/sdk/src/ssi/manifest_validation.go
@@ -1,0 +1,40 @@
+package ssi
+
+import (
+	"encoding/json"
+
+	"github.com/TBD54566975/ssi-sdk/credential/manifest"
+	"github.com/pkg/errors"
+)
+
+// IsValidCredentialApplicationForManifest validates the rules on how a credential manifest [cm] and credential
+// application [ca] relate to each other https://identity.foundation/credential-manifest/#credential-application
+//
+// Parameters:
+//
+//	cmBytes: bytes of the CredentialManfiest being validated against
+//	applicationAndCredsJSONBytes: bytes of the credential application and credentials as a JSON object
+//
+// Returns:
+//
+//	bytes of a JSON object, which outlines any unfulfilled inputDescriptors from the manifest
+func IsValidCredentialApplicationForManifest(cmBytes []byte, applicationAndCredsJSONBytes []byte) ([]byte, error) {
+	var cm manifest.CredentialManifest
+	if err := json.Unmarshal(cmBytes, &cm); err != nil {
+		return nil, errors.Wrap(err, "unmarshalling CredentialManifest")
+	}
+
+	applicationAndCredsJSON := make(map[string]any)
+	if err := json.Unmarshal(applicationAndCredsJSONBytes, &applicationAndCredsJSON); err != nil {
+		return nil, errors.Wrap(err, "unmarshalling applicationAndCredsJSON")
+	}
+
+	unfulfilledInputDescriptorsJSON, validationErr := manifest.IsValidCredentialApplicationForManifest(cm, applicationAndCredsJSON)
+
+	unfulfilledInputDescriptorsBytes, err := json.Marshal(unfulfilledInputDescriptorsJSON)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshalling unfulfilledInputDescriptorsBytes")
+	}
+
+	return unfulfilledInputDescriptorsBytes, validationErr
+}

--- a/sdk/src/ssi/manifest_validation_test.go
+++ b/sdk/src/ssi/manifest_validation_test.go
@@ -1,0 +1,104 @@
+package ssi
+
+import (
+	"embed"
+	"testing"
+
+	"github.com/TBD54566975/ssi-sdk/credential"
+	"github.com/TBD54566975/ssi-sdk/credential/manifest"
+	"github.com/goccy/go-json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	//go:embed testdata
+	testVectors embed.FS
+)
+
+const (
+	FullApplicationVector string = "full-application.json"
+	FullCredentialVector  string = "full-credential.json"
+	FullManifestVector    string = "full-manifest.json"
+)
+
+func TestIsValidCredentialApplicationForManifest(t *testing.T) {
+
+	t.Run("Credential Application and Credential Manifest Pair Valid", func(tt *testing.T) {
+		cm, ca := getValidTestCredManifestCredApplication(tt)
+
+		applicationAndCredsJSONBytes, err := json.Marshal(ca)
+		assert.NoError(tt, err)
+
+		cmBytes, err := json.Marshal(cm)
+		assert.NoError(tt, err)
+
+		unfulfilledInputDescriptorsJSONBytes, err := IsValidCredentialApplicationForManifest(cmBytes, applicationAndCredsJSONBytes)
+		assert.NoError(tt, err)
+
+		unfulfilledInputDescriptorsJSON := make(map[string]any)
+		err = json.Unmarshal(unfulfilledInputDescriptorsJSONBytes, &unfulfilledInputDescriptorsJSON)
+		assert.NoError(tt, err)
+		assert.Empty(tt, unfulfilledInputDescriptorsJSON)
+	})
+
+	t.Run("PresentationSubmission DescriptorMap mismatch id", func(tt *testing.T) {
+		cm, ca := getValidTestCredManifestCredApplication(tt)
+		ca.CredentialApplication.PresentationSubmission.DescriptorMap[0].ID = "badbadid"
+
+		applicationAndCredsJSONBytes, err := json.Marshal(ca)
+		assert.NoError(tt, err)
+
+		cmBytes, err := json.Marshal(cm)
+		assert.NoError(tt, err)
+
+		unfulfilledInputDescriptorsJSONBytes, err := IsValidCredentialApplicationForManifest(cmBytes, applicationAndCredsJSONBytes)
+		assert.Contains(t, err.Error(), "unfulfilled input descriptor")
+
+		unfulfilledInputDescriptorsJSON := make(map[string]any)
+		unmarshalJSONErr := json.Unmarshal(unfulfilledInputDescriptorsJSONBytes, &unfulfilledInputDescriptorsJSON)
+		assert.NoError(tt, unmarshalJSONErr)
+		assert.Len(tt, unfulfilledInputDescriptorsJSON, 1)
+	})
+}
+
+func getValidTestCredManifestCredApplication(t *testing.T) (manifest.CredentialManifest, manifest.CredentialApplicationWrapper) {
+	// manifest
+	manifestJSON, err := getTestVector(FullManifestVector)
+	require.NoError(t, err)
+
+	var cm manifest.CredentialManifest
+	err = json.Unmarshal([]byte(manifestJSON), &cm)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, cm)
+	require.NoError(t, cm.IsValid())
+
+	// application
+	credAppJSON, err := getTestVector(FullApplicationVector)
+	require.NoError(t, err)
+
+	var ca manifest.CredentialApplication
+	err = json.Unmarshal([]byte(credAppJSON), &ca)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, ca)
+	require.NoError(t, ca.IsValid())
+
+	vcJSON, err := getTestVector(FullCredentialVector)
+	require.NoError(t, err)
+
+	var vc credential.VerifiableCredential
+	err = json.Unmarshal([]byte(vcJSON), &vc)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, vc)
+	require.NoError(t, vc.IsValid())
+
+	return cm, manifest.CredentialApplicationWrapper{CredentialApplication: ca, Credentials: []any{vc}}
+}
+
+func getTestVector(fileName string) (string, error) {
+	b, err := testVectors.ReadFile("testdata/" + fileName)
+	return string(b), err
+}

--- a/sdk/src/ssi/testdata/full-application.json
+++ b/sdk/src/ssi/testdata/full-application.json
@@ -1,0 +1,24 @@
+{
+  "id": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d",
+  "spec_version": "https://identity.foundation/credential-manifest/spec/v1.0.0/",
+  "manifest_id": "WA-DL-CLASS-A",
+  "format": {
+    "ldp_vc": {
+      "proof_type": [
+        "JsonWebSignature2020",
+        "EcdsaSecp256k1Signature2019"
+      ]
+    }
+  },
+  "presentation_submission": {
+    "id": "a30e3b91-fb77-4d22-95fa-871689c322e2",
+    "definition_id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+    "descriptor_map": [
+      {
+        "id": "kycid1",
+        "format": "jwt_vc",
+        "path": "$.verifiableCredentials[0]"
+      }
+    ]
+  }
+}

--- a/sdk/src/ssi/testdata/full-credential.json
+++ b/sdk/src/ssi/testdata/full-credential.json
@@ -1,0 +1,18 @@
+{
+  "@context": "https://www.w3.org/2018/credentials/v1",
+  "id": "https://eu.com/claims/DriversLicense",
+  "type": [
+    "EUDriversLicense"
+  ],
+  "issuer": "did:example:123",
+  "issuanceDate": "2010-01-01T19:23:24Z",
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "givenName": "ricky bobby",
+    "additionalName": "hank hill",
+    "familyName": "simpson",
+    "birthDate": "2009-01-03",
+    "postalAddress": "p sherman 42 wallaby way, sydney",
+    "taxID": "123"
+  }
+}

--- a/sdk/src/ssi/testdata/full-manifest.json
+++ b/sdk/src/ssi/testdata/full-manifest.json
@@ -1,0 +1,94 @@
+{
+  "id": "WA-DL-CLASS-A",
+  "issuer": {
+    "id": "did:example:123"
+  },
+  "spec_version": "https://identity.foundation/credential-manifest/spec/v1.0.0/",
+  "output_descriptors": [
+    {
+      "id": "kyc_credential",
+      "schema": "https://compliance-is-kewl.com/json-schemas/kyc.json"
+    }
+  ],
+  "presentation_definition": {
+    "id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+    "name": "KYC Requirements",
+    "purpose": "purpose",
+    "format": {
+      "jwt": {
+        "alg": [
+          "EdDSA"
+        ]
+      }
+    },
+    "input_descriptors": [
+      {
+        "id": "kycid1",
+        "name": "Personal Info",
+        "constraints": {
+          "subject_is_issuer": "required",
+          "fields": [
+            {
+              "id": "givenName",
+              "path": [
+                "$.credentialSubject.givenName"
+              ],
+              "filter": {
+                "type": "string",
+                "pattern": "[a-zA-Z \\-\\.].+"
+              }
+            },
+            {
+              "id": "additionalName",
+              "path": [
+                "$.credentialSubject.additionalName"
+              ],
+              "filter": {
+                "type": "string",
+                "pattern": "[a-zA-Z \\-\\.].+"
+              }
+            },
+            {
+              "id": "familyName",
+              "path": [
+                "$.credentialSubject.familyName"
+              ],
+              "filter": {
+                "type": "string",
+                "pattern": "[a-zA-Z \\-\\.].+"
+              }
+            },
+            {
+              "id": "birthDate",
+              "path": [
+                "$.credentialSubject.birthDate"
+              ],
+              "filter": {
+                "type": "string",
+                "format": "date"
+              }
+            },
+            {
+              "id": "postalAddress",
+              "path": [
+                "$.credentialSubject.postalAddress"
+              ],
+              "filter": {
+                "type": "string"
+              }
+            },
+            {
+              "id": "taxID",
+              "path": [
+                "$.credentialSubject.taxID"
+              ],
+              "filter": {
+                "type": "string"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Exposes the `IsValidCredentialApplicationForManifest` function to mobile clients. 

This function does all the heavy lifting of validating that a given Credential Application is valid for a particular manifest, and we'll leverage this on the mobile clients to convey errors with the application process!

I ported over two tests from the `ssi-sdk`'s test suite to validate it was working properly. Happy to add more if we feel like there are any mobile-specific considerations to take here. I mainly just wanted to test that it was calling into the original go code properly, as that's what's doing the heavy lifting!